### PR TITLE
Fix embedded rootfs without chroot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ install: all symlinks.8
 	$(INSTALL) -c -o $(OWNER) -g $(GROUP) -m 755 symlinks $(BINDIR)
 	$(INSTALL) -c -o $(OWNER) -g $(GROUP) -m 644 symlinks.8 $(MANDIR)
 
+.PHONY: test
+test: clean symlinks
+	@test/generate-rootfs.sh
+	@test/run-tests.sh
+
 .PHONY: clean
 clean:
-	rm -f symlinks *.o core
+	rm -f symlinks *.o *~ core
+	rm -fr test/rootfs

--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,10 @@ Usage
 
     $ symlinks -rc [path]
 
+### Convert absolute symlinks in an embedded rootfs, which lies within the
+    system rootfs, e.g. in /gpfs/sys/ubuntu11.04. Make sure to cd into rootfs before executing:
+    $ cd /gpfs/sys/ubuntu11.04
+    $ symlinks -rec [path] 
 
 ### More options:
 

--- a/Readme.md
+++ b/Readme.md
@@ -38,8 +38,7 @@ Usage
 
     $ symlinks -rc [path]
 
-### Convert absolute symlinks in an embedded rootfs, which lies within the
-    system rootfs, e.g. in /gpfs/sys/ubuntu11.04. Make sure to cd into rootfs before executing:
+### Convert absolute symlinks in an embedded rootfs, which lies within the system rootfs, e.g. in /gpfs/sys/ubuntu11.04. Make sure to cd into rootfs before executing:
     $ cd /gpfs/sys/ubuntu11.04
     $ symlinks -rec [path] 
 

--- a/symlinks.8
+++ b/symlinks.8
@@ -102,6 +102,11 @@ would do if
 .B -c
 were specified, but without really changing anything.
 .TP
+.I -e
+work on an embedded rootfs which is relative to the system rootfs without
+the need to chroot / fakechroot into it, e.g. in /gpfs/sys/ubuntu11.04.
+Make sure to cd into rootfs before executing
+.TP
 .I -v 
 show all symbolic links.  By default, 
 .B relative

--- a/test/generate-rootfs.sh
+++ b/test/generate-rootfs.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Unit test for symlinks
+# Generate artificial rootfs for testing purpose
+#
+
+SYMLINKS_BIN=../symlinks
+ROOTFS_FOLDER=rootfs
+TEST_FOLDER=$(dirname $0)
+
+# create rootfs folder and cd into it
+mkdir -p $TEST_FOLDER/$ROOTFS_FOLDER
+cd $TEST_FOLDER/$ROOTFS_FOLDER
+
+echo "* Creating artificial rootfs in $TEST_FOLDER/$ROOTFS_FOLDER"
+
+
+###################################################################################################
+# Create an example rootfs 
+###################################################################################################
+mkdir -p    usr                                   \
+            lib                                   \
+            etc                                   \
+            opt                                   \
+            usr/bin                               \
+            usr/sbin                              \
+            usr/share                             \
+            usr/lib                               \
+            usr/lib/toolchain/bin                 \
+            usr/lib/libsomething                  \
+            usr/lib/jvm/java-1.5-jdk-1.5.2/bin    \
+            etc/alternatives                      \
+            lib/toolchain1/bin                    \
+            lib/toolchain2/bin    
+
+touch       usr/lib/libsomething/libsomething.so.1.1.1   \
+            usr/lib/libsomething/libsomething.so.1.1.2    \
+            usr/lib/libsomething/libsomething.so.1.2.1    \
+            usr/lib/libsomething/libsomething.so.1.2.2    \
+            usr/lib/libsomething/libsomething.so.1.2.3    \
+            usr/lib/libsomething/libsomething.so.2.1.1    \
+            usr/lib/libsomething/libsomething.so.2.1.2    \
+            usr/lib/libsomething/libsomething.so.2.1.3    \
+            lib/toolchain1/bin/tool1                      \
+            lib/toolchain1/bin/tool2                      \
+            lib/toolchain2/bin/tool1                      \
+            lib/toolchain2/bin/tool2                      \
+            usr/lib/jvm/java-1.5-jdk-1.5.2/jdk-config     \
+            usr/lib/jvm/java-1.5-jdk-1.5.2/bin/java
+
+###################################################################################################
+# Test case #1:     normal chained / cascaded symlinks in the case of software versioning
+#
+# Expected Result:  do nothing, everything is fine here!
+###################################################################################################
+ln -sf  libsomething.so.1.1.2 \
+        usr/lib/libsomething/libsomething.so.1.1
+ln -sf  libsomething.so.1.2.3 \
+        usr/lib/libsomething/libsomething.so.1.2
+ln -sf  libsomething.so.1.2.3 \
+        usr/lib/libsomething/libsomething.so.1
+ln -sf  libsomething.so.2.1.3 \
+        usr/lib/libsomething/libsomething.so.2.1
+ln -sf  libsomething.so.2.1 \
+        usr/lib/libsomething/libsomething.so.2
+ln -sf  libsomething.so.2 \
+        usr/lib/libsomething/libsomething.so
+ln -s   java-1.5-jdk-1.5.2 \
+        usr/lib/jvm/java-1.5-jdk
+
+###################################################################################################
+# Test case #2:     absolute symlinks
+#
+# Expected result:  change absolute symlinks into relative ones
+###################################################################################################
+ln -sf  /lib/toolchain2/bin/tool1    \
+        usr/lib/toolchain/bin/
+ln -sf  /lib/toolchain2/bin/tool2    \
+        usr/lib/toolchain/bin/
+
+
+###################################################################################################
+# Test case #3:     detect dangling symlinks as in the case of messed up library versioning
+#
+# Expected result:  detect and delete all symlinks which are involved
+###################################################################################################
+# now let's create a symlink to a target which doesn't exist
+ln -sf  libsomething.so.2.1.4       \
+        usr/lib/libsomething/libsomething.so.2.1
+
+
+###################################################################################################
+# Test case #4:     recursive mess of absolute symlinks
+#
+# Expected result:  resolve all symlinks, at least after second run!
+###################################################################################################
+ln -sf  /usr/lib/toolchain/bin/tool1            \
+        etc/alternatives/
+ln -sf  /usr/lib/toolchain/bin/tool2            \
+        etc/alternatives/
+ln -sf  /usr/lib/jvm/java-1.5-jdk               \
+        etc/alternatives/java-sdk
+ln -sf  /usr/lib/jvm/java-1.5-jdk/bin/java      \
+        etc/alternatives/java
+ln -sf  /etc/alternatives/java                  \
+        usr/bin/
+

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Unit test for symlinks
+# Run test on a test set e.g. an artificially created rootfs
+#
+
+SYMLINKS_BIN=../symlinks
+ROOTFS_FOLDER=rootfs
+ROOTFS_DANGLING_LINKS=3
+TEST_FOLDER=$(dirname $0)
+
+echo "* Running unit tests on $TEST_FOLDER/$ROOTFS_FOLDER"
+
+
+###################################################################################################
+# Simple test which should cover all test cases implemented in (generate-rootfs.sh):
+#
+# Test case #1:       normal chained / cascaded symlinks in the case of software versioning
+# Expected Result:    do nothing, everything is fine here!
+#
+# Test case #2:       absolute symlinks
+# Expected result:    change absolute symlinks into relative ones
+#
+# Test case #3:       detect dangling symlinks as in the case of messed up library versioning
+# Expected result:    detect and delete all symlinks which are involved
+#
+# Test case #4:       recursive mess of absolute symlinks
+# Expected result:    resolve all symlinks, at least after second run!
+###################################################################################################
+
+# let's run symlink against the just generated rootfs folder and see how it does:
+
+# cd into rootfs folder first
+cd $TEST_FOLDER/$ROOTFS_FOLDER
+
+# call 'symlinks' to convert all absolute symlinks to relative ones with the following options:
+#     -v    verbose
+#     -r    recursive
+#     -c    change absolute links into relative links
+COUNT=0
+while [ "$(../$SYMLINKS_BIN -verc . | grep absolute)" ]; do
+    COUNT=$((COUNT+1))
+    echo "Test run #$COUNT"
+done
+
+# call 'symlinks' again to get rid of the remaining dangling symlinks which could not be fixed
+echo "Last run to fix the remaining dangling symlinks"
+DANGLING_SYMLINKS_COUNT=$(../$SYMLINKS_BIN -verd . | grep dangling | wc -l)
+echo "Removed $DANGLING_SYMLINKS_COUNT dangling links!"
+if [ $DANGLING_SYMLINKS_COUNT -lt $ROOTFS_DANGLING_LINKS ]; then
+    echo "Detected and removed too less broken symlinks!"
+elif [ $DANGLING_SYMLINKS_COUNT -gt $ROOTFS_DANGLING_LINKS ]; then
+    echo "Detected and removed too many broken symlinks!"
+fi
+
+# now let's look if there are broken symlinks left, 'find' offers some easy way to do that
+BROKEN_SYMLINKS=$(find -L -type l)
+
+# and also if there are still existing (maybe even working) absolute symlinks left
+ABSOLUTE_SYMLINKS=$(find -type l -exec readlink {} \; | grep "^/")
+
+if [ "$BROKEN_SYMLINKS" ] || [ "$ABSOLUTE_SYMLINKS" ]; then
+    echo "Test failed, program was not able to fix all symlink problems..."
+    if [ "$BROKEN_SYMLINKS" ]; then
+        echo "The following symlinks have not been fixed:"
+        for link in $BROKEN_SYMLINKS; do
+            echo -e "\t * $link -> $(readlink $link)"
+        done
+    fi
+    
+    if [ "$ABSOLUTE_SYMLINKS" ]; then
+        echo "There are still (maybe even working) absolute symlinks left:"
+        for link in $ABSOLUTE_SYMLINKS; do
+            echo -e "\t * $link -> $(readlink $link)"
+        done
+    fi
+else
+    echo "Test succeeded, it seems symlinks was able to solve all symlink problems!"
+fi
+
+


### PR DESCRIPTION
Symlinks should be also able to fix symlinks of embedded root filesystems which lie within the system rootfs, without the need of chroot or fakechroot.
Option '-e' was added to make symlinks know that it's working on a relative rootfs.

For testing purposes I added a little testsuite which creates an artificial rootfs and tests the usual symlink cases.
