### PR TITLE
Clarify `make install` step of README; allow PREFIX, MANDIR, BINDIR override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 # Makefile for symlinks
 CC      = gcc
+# append options like `-o owner -g group` here if desired
 INSTALL = install
 CFLAGS += $(shell getconf LFS_CFLAGS 2>/dev/null)
-OWNER   = root
-GROUP   = root
 PREFIX ?= /usr/local
-MANDIR ?= $(PREFIX)/share/man/man8/symlinks.8
+MANDIR ?= $(PREFIX)/share/man/man8
 BINDIR ?= $(PREFIX)/bin
 
 
@@ -16,8 +15,10 @@ symlinks: symlinks.c
 	$(CC) -Wall -Wstrict-prototypes -O2 $(CFLAGS) -o symlinks symlinks.c
 
 install: all symlinks.8
-	$(INSTALL) -c -o $(OWNER) -g $(GROUP) -m 755 symlinks $(BINDIR)
-	$(INSTALL) -c -o $(OWNER) -g $(GROUP) -m 644 symlinks.8 $(MANDIR)
+	$(INSTALL) -d $(BINDIR)
+	$(INSTALL) -m 755 symlinks $(BINDIR)
+	$(INSTALL) -d $(MANDIR)
+	$(INSTALL) -m 644 symlinks.8 $(MANDIR)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 # Makefile for symlinks
-CC     := gcc
+CC      = gcc
+INSTALL = install
 CFLAGS += $(shell getconf LFS_CFLAGS 2>/dev/null)
 OWNER   = root
 GROUP   = root
-MANDIR  = /usr/man/man8/symlinks.8
-BINDIR  = /usr/local/bin
+PREFIX ?= /usr/local
+MANDIR ?= $(PREFIX)/share/man/man8/symlinks.8
+BINDIR ?= $(PREFIX)/bin
+
 
 .PHONY: all
 all: symlinks

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ install: all symlinks.8
 	$(INSTALL) -d $(MANDIR)
 	$(INSTALL) -m 644 symlinks.8 $(MANDIR)
 
+uninstall:
+	-rm -i $(BINDIR)/symlinks
+	-rm -i $(MANDIR)/symlinks.8
+
 .PHONY: clean
 clean:
 	rm -f symlinks *.o core

--- a/Readme.md
+++ b/Readme.md
@@ -20,9 +20,9 @@ Installation
     $ make
     $ make install  # or 'sudo make install' if you get an error
 
-If you would like to install to some other location besides the default of `/usr/local/bin`, which usually requires admin privileges, then add `PREFIX=/some/other/path` to the end of your `make install`. For example:
+If you would like to install to some other location besides the default of `/usr/local`, which usually requires admin privileges, then add `PREFIX=/some/other/path` to the end of your `make install`. For example:
 
-    $ make install PREFIX=$HOME/.local/bin
+    $ make install PREFIX=$HOME/.local
 
 ### Pre-compiled binaries:
 

--- a/Readme.md
+++ b/Readme.md
@@ -16,9 +16,19 @@ Installation
 
 ### Source:
 
-    $ ./configure
+    $ cd path/to/the/extracted/source
     $ make
-    $ make install
+    $ make install  # or 'sudo make install' if you get an error
+
+If you would like to install to some other location besides the default of `/usr/local/bin`, which usually requires admin privileges, then add `PREFIX=/some/other/path` to the end of your `make install`. For example:
+
+    $ make install PREFIX=$HOME/.local/bin
+
+### Pre-compiled binaries:
+
+Many Linux distributions already have a version of Mark Lord's original `symlinks` in their repositories; see https://pkgs.org/search/?q=symlinks for details.
+
+If you use MacPorts, you can `sudo port install symlinks`.
 
 
 Usage


### PR DESCRIPTION
- fixes brandt/symlinks#9
- fixes brandt/symlinks#4
    * allowing `make install PREFIX=…` from the environment should address any concerns about lack of a `./configure` script from that issue